### PR TITLE
Adding user agent header when fetching resources from IGV (#1)

### DIFF
--- a/seqr/views/apis/igv_api.py
+++ b/seqr/views/apis/igv_api.py
@@ -209,7 +209,7 @@ def igv_genomes_proxy(request, file_path):
     range_header = request.META.get('HTTP_RANGE')
     if range_header:
         headers['Range'] = range_header
-
+    headers["User-Agent"] = "Mozilla/5.0 (X11; Linux x86_64; rv:130.0) Gecko/20100101 Firefox/130.0"
     genome_response = requests.get('https://s3.amazonaws.com/igv.{}'.format(file_path), headers=headers)
     proxy_response = HttpResponse(
         content=genome_response.content,


### PR DESCRIPTION
IGV get requests seem to fail when UA is not specified. Adding it here with any modern UA seems to work.

Notably, a curl UA doesn't work.